### PR TITLE
removed unsafety from slabmalloc design

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,9 +62,9 @@ use core::alloc::Layout;
 use core::fmt;
 use core::mem;
 use core::ptr::{self, NonNull};
-use memory::MappedPages;
+use memory::{VirtualAddress, MappedPages, create_mapping, EntryFlags};
 
-use log::{error};
+use log::{error,trace};
 
 #[cfg(target_arch = "x86_64")]
 const CACHE_LINE_SIZE: usize = 64;
@@ -92,14 +92,10 @@ pub enum AllocationError {
 pub unsafe trait Allocator<'a> {
     fn allocate(&mut self, layout: Layout) -> Result<NonNull<u8>, &'static str>;
     fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str>;
-    // unsafe fn refill_large(
-    //     &mut self,
-    //     layout: Layout,
-    //     new_page: &'a mut LargeObjectPage<'a>,
-    // ) -> Result<(), AllocationError>;
     fn refill(
         &mut self,
         layout: Layout,
-        mp: MappedPages,
+        mp: MappedPages8k,
     ) -> Result<(), &'static str>;
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! A slab allocator implementation for objects less than a page-size (4 KiB or 2MiB).
+//! A slab allocator implementation for objects less than 8 KiB.
 //!
 //! # Overview
 //!
@@ -7,21 +7,13 @@
 //!  * A `ZoneAllocator` manages many `SCAllocator` and can
 //!    satisfy requests for different allocation sizes.
 //!  * A `SCAllocator` allocates objects of exactly one size.
-//!    It stores the objects and meta-data in one or multiple `AllocablePage` objects.
-//!  * A trait `AllocablePage` that defines the page-type from which we allocate objects.
+//!    It stores the objects and meta-data in the pages represented by 'MappedPages8k' objects.
 //!
-//! Lastly, it provides two default `AllocablePage` implementations `ObjectPage` and `LargeObjectPage`:
-//!  * A `ObjectPage` that is 4 KiB in size and contains allocated objects and associated meta-data.
-//!  * A `LargeObjectPage` that is 2 MiB in size and contains allocated objects and associated meta-data.
-//!
+//! Lastly, it provides an `ObjectPage8k` type that represents the layout of the 8 KiB pages, and the MappedPages8k type
+//! which represent memory granted to the heap by the OS. 
 //!
 //! # Implementing GlobalAlloc
 //! See the [global alloc](https://github.com/gz/rust-slabmalloc/tree/master/examples/global_alloc.rs) example.
-//! 
-//! # Theseus 
-//! Some changes made for the Theseus OS heap:
-//!  * A `ObjectPage8k` that is 8 KiB in size and contains allocated objects and associated meta-data.
-//!  * return_page() function which allow the ZoneAllocator to return empty pages on request.
 #![allow(unused_features)]
 #![cfg_attr(feature = "unstable", feature(const_fn))]
 #![cfg_attr(
@@ -59,7 +51,6 @@ extern crate test;
 mod tests;
 
 use core::alloc::Layout;
-use core::fmt;
 use core::mem;
 use core::ptr::{self, NonNull};
 use memory::{VirtualAddress, MappedPages, create_mapping, EntryFlags};
@@ -76,8 +67,6 @@ const CACHE_LINE_SIZE: usize = 64;
 #[allow(unused)]
 const LARGE_PAGE_SIZE: usize = 2 * 1024 * 1024;
 
-#[cfg(target_arch = "x86_64")]
-type VAddr = usize;
 
 /// Error that can be returned for `allocation` and `deallocation` requests.
 #[derive(Debug)]

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use core::sync::atomic::{AtomicU64, Ordering};
+use core::ops::{Deref, DerefMut};
 
 /// A trait defining bitfield operations we need for tracking allocated objects within a page.
 pub(crate) trait Bitfield {
@@ -20,7 +21,7 @@ pub(crate) trait Bitfield {
 
 /// Implementation of bit operations on u64 slices.
 ///
-/// We allow deallocations (i.e. clearning a bit in the field)
+/// We allow deallocations (i.e. clearing a bit in the field)
 /// from any thread. That's why the bitfield is a bunch of AtomicU64.
 impl Bitfield for [AtomicU64] {
     /// Initialize the bitfield
@@ -150,43 +151,80 @@ impl Bitfield for [AtomicU64] {
     }
 }
 
-/// This trait is used to define a page from which objects are allocated
-/// in an `SCAllocator`.
+
+/// Holds allocated data within 2 4-KiB pages.
 ///
-/// The implementor of this trait needs to provide access to the page meta-data,
-/// which consists of:
-/// - A bitfield (to track allocations),
-/// - `prev` and `next` pointers to insert the page in free lists
-pub trait AllocablePage {
-    /// The total size (in bytes) of the page.
-    ///
-    /// # Note
-    /// We also assume that the address of the page will be aligned to `SIZE`.
-    const SIZE: usize;
+/// Has a data-section where objects are allocated from
+/// and a small amount of meta-data in form of a bitmap
+/// to track allocations at the end of the page.
+///
+/// # Notes
+/// An object of this type will be exactly 8 KiB.
+/// It is marked `repr(C)` because we rely on a well defined order of struct
+/// members (e.g., dealloc does a cast to find the bitfield).
+#[repr(C)]
+pub struct ObjectPage8k {
+    /// Holds memory objects.
+    #[allow(dead_code)]
+    data: [u8; ObjectPage8k::SIZE -ObjectPage8k::METADATA_SIZE],
 
-    const METADATA_SIZE: usize;
+    pub heap_id: usize,
 
-    const HEAP_ID_OFFSET: usize;
+    /// Next element in list (used by `PageList`).
+    next_mp: Option<MappedPages8k>,
 
-    fn new(mp: MappedPages, heap_id: usize) -> Result<Self, &'static str>
-    where
-        Self: core::marker::Sized;
-    fn retrieve_mapped_pages(&mut self) -> MappedPages;
-    fn clear_metadata(&mut self);
-    fn set_heap_id(&mut self, heap_id: usize);
-    fn heap_id(&self) -> usize;
-    fn bitfield(&self) -> &[AtomicU64; 8];
-    fn bitfield_mut(&mut self) -> &mut [AtomicU64; 8];
-    fn prev(&mut self) -> &mut Rawlink<Self>
-    where
-        Self: core::marker::Sized;
-    fn next(&mut self) -> &mut Rawlink<Self>
-    where
-        Self: core::marker::Sized;
-    fn buffer_size() -> usize;
+    /// A bit-field to track free/allocated memory within `data`.
+    pub(crate) bitfield: [AtomicU64; 8],
+}
+
+
+// These needs some more work to be really safe...
+unsafe impl Send for ObjectPage8k {}
+unsafe impl Sync for ObjectPage8k {}
+
+impl ObjectPage8k {
+    pub const SIZE: usize = 8192;
+    pub const METADATA_SIZE: usize = core::mem::size_of::<Option<MappedPages>>() + core::mem::size_of::<usize>()  + (8*8);
+    pub const HEAP_ID_OFFSET: usize = Self::SIZE - (core::mem::size_of::<Option<MappedPages>>() + core::mem::size_of::<usize>() + (8*8));
+
+    /// clears the metadata section of the page
+    pub fn clear_metadata(&mut self) {
+        self.heap_id = 0;
+        let mut mp = None;
+        core::mem::swap(&mut mp, &mut self.next_mp);
+        core::mem::forget(mp);
+        // self.next_mp = None; // If we start with an uninitialized ObjectPage8k, then this will cause an error message in MappedPages::drop() due to difference in page tables
+        for bf in &self.bitfield {
+            bf.store(0, Ordering::SeqCst);
+        }
+    }
+
+    pub fn set_heap_id(&mut self, heap_id: usize){
+        self.heap_id = heap_id;
+    }
+
+    pub fn heap_id(&self) -> usize {
+        self.heap_id
+    }
+
+    pub fn bitfield(&self) -> &[AtomicU64; 8] {
+        &self.bitfield
+    }
+    
+    pub fn bitfield_mut(&mut self) -> &mut [AtomicU64; 8] {
+        &mut self.bitfield
+    }
+
+    pub fn next(&mut self) -> &mut Option<MappedPages8k> {
+        &mut self.next_mp
+    }
+
+    pub fn buffer_size() -> usize {
+        ObjectPage8k::SIZE - ObjectPage8k::METADATA_SIZE
+    }
 
     /// Tries to find a free block within `data` that satisfies `alignment` requirement.
-    fn first_fit(&self, layout: Layout) -> Option<(usize, usize)> {
+    pub fn first_fit(&self, layout: Layout) -> Option<(usize, usize)> {
         let base_addr = (&*self as *const Self as *const u8) as usize;
         self.bitfield().first_fit(base_addr, layout, Self::SIZE, Self::METADATA_SIZE)
     }
@@ -194,7 +232,7 @@ pub trait AllocablePage {
     /// Tries to allocate an object within this page.
     ///
     /// In case the slab is full, returns a null ptr.
-    fn allocate(&mut self, layout: Layout) -> *mut u8 {
+    pub fn allocate(&mut self, layout: Layout) -> *mut u8 {
         match self.first_fit(layout) {
             Some((idx, addr)) => {
                 self.bitfield().set_bit(idx);
@@ -205,17 +243,17 @@ pub trait AllocablePage {
     }
 
     /// Checks if we can still allocate more objects of a given layout within the page.
-    fn is_full(&self) -> bool {
+    pub fn is_full(&self) -> bool {
         self.bitfield().is_full()
     }
 
     /// Checks if the page has currently no allocations.
-    fn is_empty(&self, relevant_bits: usize) -> bool {
+    pub fn is_empty(&self, relevant_bits: usize) -> bool {
         self.bitfield().all_free(relevant_bits)
     }
 
     /// Deallocates a memory object within this page.
-    fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
+    pub fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
         // trace!(
         //     "AllocablePage deallocating ptr = {:p} with {:?}",
         //     ptr,
@@ -236,50 +274,17 @@ pub trait AllocablePage {
 }
 
 
-/// Holds allocated data within 2 4-KiB pages.
-///
-/// Has a data-section where objects are allocated from
-/// and a small amount of meta-data in form of a bitmap
-/// to track allocations at the end of the page.
-///
-/// # Notes
-/// An object of this type will be exactly 8 KiB.
-/// It is marked `repr(C)` because we rely on a well defined order of struct
-/// members (e.g., dealloc does a cast to find the bitfield).
-#[repr(C)]
-pub struct ObjectPage8k<'a> {
-    /// Holds memory objects.
-    #[allow(dead_code)]
-    data: [u8; ObjectPage8k::SIZE -ObjectPage8k::METADATA_SIZE],
+pub struct MappedPages8k(MappedPages);
+
+impl MappedPages8k {
+    pub const SIZE: usize = ObjectPage8k::SIZE;
+    pub const METADATA_SIZE: usize = ObjectPage8k::METADATA_SIZE;
+    pub const HEAP_ID_OFFSET: usize = ObjectPage8k::HEAP_ID_OFFSET;
     
-    pub mp: MappedPages,
-
-    pub heap_id: usize,
-
-    /// Next element in list (used by `PageList`).
-    next: Rawlink<ObjectPage8k<'a>>,
-    /// Previous element in  list (used by `PageList`)
-    prev: Rawlink<ObjectPage8k<'a>>,
-
-    /// A bit-field to track free/allocated memory within `data`.
-    pub(crate) bitfield: [AtomicU64; 8],
-}
-
-
-// These needs some more work to be really safe...
-unsafe impl<'a> Send for ObjectPage8k<'a> {}
-unsafe impl<'a> Sync for ObjectPage8k<'a> {}
-
-impl<'a> AllocablePage for ObjectPage8k<'a> {
-    const SIZE: usize = 8192;
-    const METADATA_SIZE: usize = core::mem::size_of::<MappedPages>() + core::mem::size_of::<usize>() + (2*core::mem::size_of::<Rawlink<ObjectPage8k<'a>>>()) + (8*8);
-    const HEAP_ID_OFFSET: usize = Self::SIZE - (core::mem::size_of::<usize>() + (2*core::mem::size_of::<Rawlink<ObjectPage8k<'a>>>()) + (8*8));
-
-    /// Creates a new 8KiB allocable page and stores the MappedPages object in the metadata portion.
-    /// This function checks that the given mapped pages is aligned at a 8KiB boundary, writable and has a size of 8KiB.
-    fn new(mp: MappedPages, heap_id: usize) -> Result<ObjectPage8k<'a>, &'static str> {
+    pub fn new(mp: MappedPages) -> Result<MappedPages8k, &'static str> {
         let vaddr = mp.start_address().value();
         
+        // check that the mapped pages are aligned to 8k
         if vaddr % Self::SIZE != 0 {
             error!("The mapped pages for the heap are not aligned at 8k bytes");
             return Err("The mapped pages for the heap are not aligned at 8k bytes");
@@ -297,87 +302,61 @@ impl<'a> AllocablePage for ObjectPage8k<'a> {
             return Err("MappedPages size does not equal allocable page size");
         }
 
-        Ok( ObjectPage8k {
-            data: [0; ObjectPage8k::SIZE -ObjectPage8k::METADATA_SIZE],
-            mp: mp,
-            heap_id: heap_id,
-            next: Rawlink::default(),
-            prev: Rawlink::default(),
-            bitfield: [AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0),AtomicU64::new(0) ],
-        })
+        let mut mp_8k = MappedPages8k(mp);
+        mp_8k.clear_metadata();
+        Ok(mp_8k)
     }
 
-    /// Returns the MappedPages object that was stored in the metadata portion of the page,
-    /// by swapping with an empty MappedPages object.
-    /// 
-    /// Marked unsafe since it should only be used when the the AllocablePage it applies to is removed from the heap's linked list and isn't used again
-    fn retrieve_mapped_pages(&mut self) -> MappedPages {
-        let mut mp = MappedPages::empty();
-        core::mem::swap(&mut self.mp, &mut mp);
-        mp
-    }
-
-    /// clears the metadata section of the page
-    fn clear_metadata(&mut self) {
-        self.heap_id = 0;
-        self.next = Rawlink::default();
-        self.prev = Rawlink::default();
-        for bf in &self.bitfield {
-            bf.store(0, Ordering::SeqCst);
+    fn as_ObjectPage8k(&self) -> &ObjectPage8k {
+        // SAFE: we guarantee the size and lifetime are within that of this MappedPages object
+        unsafe {
+            mem::transmute(self.0.start_address())
         }
     }
 
-    fn set_heap_id(&mut self, heap_id: usize){
-        self.heap_id = heap_id;
+    fn as_ObjectPage8k_mut(&mut self) -> &mut ObjectPage8k {
+        // SAFE: we guarantee the size and lifetime are within that of this MappedPages object
+        unsafe {
+            mem::transmute(self.0.start_address())
+        }
     }
 
-    fn heap_id(&self) -> usize {
-        self.heap_id
-    }
-
-    fn bitfield(&self) -> &[AtomicU64; 8] {
-        &self.bitfield
-    }
-    fn bitfield_mut(&mut self) -> &mut [AtomicU64; 8] {
-        &mut self.bitfield
-    }
-
-    fn prev(&mut self) -> &mut Rawlink<Self> {
-        &mut self.prev
-    }
-
-    fn next(&mut self) -> &mut Rawlink<Self> {
-        &mut self.next
-    }
-
-    fn buffer_size() -> usize {
-        ObjectPage8k::SIZE - ObjectPage8k::METADATA_SIZE
+    pub fn start_address(&self) -> VirtualAddress {
+        self.0.start_address()
     }
 }
 
-impl<'a> Default for ObjectPage8k<'a> {
-    fn default() -> ObjectPage8k<'a> {
-        unsafe { mem::MaybeUninit::zeroed().assume_init() }
+impl<'a> Deref for MappedPages8k {
+    type Target = ObjectPage8k;
+    fn deref(&self) -> &ObjectPage8k {
+        self.as_ObjectPage8k()
+    }
+}
+impl<'a> DerefMut for MappedPages8k {
+    fn deref_mut(&mut self) -> &mut ObjectPage8k {
+        self.as_ObjectPage8k_mut()
     }
 }
 
-impl<'a> fmt::Debug for ObjectPage8k<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ObjectPage8k")
-    }
-}
+// These needs some more work to be really safe...
+unsafe impl Send for MappedPages8k {}
+unsafe impl Sync for MappedPages8k {}
 
-/// A list of pages.
-pub(crate) struct PageList<'a, T: AllocablePage> {
-    /// Points to the head of the list.
-    pub(crate) head: Option<&'a mut T>,
+
+
+/// A list of MappedPages8k which represent 8KiB of memory.
+/// Rather than using pointers to create a linked list, we store each successive MappedPages8k object within the 
+/// memory of the previous MappedPages8k.
+pub(crate) struct PageList {
+    /// The head of the list.
+    pub(crate) head: Option<MappedPages8k>,
     /// Number of elements in the list.
     pub(crate) elements: usize,
 }
 
-impl<'a, T: AllocablePage> PageList<'a, T> {
+impl PageList {
     #[cfg(feature = "unstable")]
-    pub(crate) const fn new() -> PageList<'a, T> {
+    pub(crate) const fn new() -> PageList {
         PageList {
             head: None,
             elements: 0,
@@ -385,100 +364,99 @@ impl<'a, T: AllocablePage> PageList<'a, T> {
     }
 
     #[cfg(not(feature = "unstable"))]
-    pub(crate) fn new() -> PageList<'a, T> {
+    pub(crate) fn new() -> PageList {
         PageList {
             head: None,
             elements: 0,
         }
     }
 
-    pub(crate) fn iter_mut<'b: 'a>(&mut self) -> ObjectPageIterMut<'b, T> {
+    pub(crate) fn iter_mut<'a>(&mut self) -> MappedPages8kIterMut<'a> {
         let m = match self.head {
             None => Rawlink::none(),
-            Some(ref mut m) => Rawlink::some(*m),
+            Some(ref mut m) => Rawlink::some(m),
         };
 
-        ObjectPageIterMut {
+        MappedPages8kIterMut {
             head: m,
             phantom: core::marker::PhantomData,
         }
     }
 
     /// Inserts `new_head` at the front of the list.
-    pub(crate) fn insert_front<'b>(&'b mut self, mut new_head: &'a mut T) {
+    pub(crate) fn insert_front(&mut self, mut new_head: MappedPages8k) {
         match self.head {
             None => {
-                *new_head.prev() = Rawlink::none();
                 self.head = Some(new_head);
             }
             Some(ref mut head) => {
-                *new_head.prev() = Rawlink::none();
-                *head.prev() = Rawlink::some(new_head);
                 mem::swap(head, &mut new_head);
-                *head.next() = Rawlink::some(new_head);
+                *head.next() = Some(new_head);
             }
         }
 
         self.elements += 1;
     }
 
-    /// Removes `slab_page` from the list.
-    pub(crate) fn remove_from_list(&mut self, slab_page: &mut T) {
-        unsafe {
-            match slab_page.prev().resolve_mut() {
-                None => {
-                    self.head = slab_page.next().resolve_mut();
-                }
-                Some(prev) => {
-                    *prev.next() = match slab_page.next().resolve_mut() {
-                        None => Rawlink::none(),
-                        Some(next) => Rawlink::some(next),
-                    };
+    /// Removes the MappedPages8k from the list which has the starting address `page_start_addr`.
+    pub(crate) fn remove_from_list(&mut self, page_start_addr: VirtualAddress) -> Option<MappedPages8k> {
+        let mut head = &mut self.head;
+        match head {
+            None => return None,
+            Some(ref mut mp) => {
+                if mp.start_address() == page_start_addr {
+                    let mut found_mp = self.head.take();
+                    self.head = found_mp.as_mut().unwrap().next().take();
+                    self.elements -= 1;
+                    return found_mp;
                 }
             }
+        };
 
-            match slab_page.next().resolve_mut() {
-                None => (),
-                Some(next) => {
-                    *next.prev() = match slab_page.prev().resolve_mut() {
-                        None => Rawlink::none(),
-                        Some(prev) => Rawlink::some(prev),
-                    };
+        loop {
+            match head {
+                None => return None,
+                Some(ref mut mp) => {
+                    match mp.next() {
+                        None => return None,
+                        Some(ref mut mp_next) => {
+                            if mp_next.start_address() == page_start_addr {
+                                let mut found_mp = mp.next().take();
+                                let new_next = found_mp.as_mut().unwrap().next().take();
+                                *mp.next() = new_next;
+
+                                self.elements -= 1;
+                                return found_mp
+                            }
+                            else {
+                                head = mp.next();
+                            }
+                        }
+                    }
                 }
             }
         }
-
-        *slab_page.prev() = Rawlink::none();
-        *slab_page.next() = Rawlink::none();
-        self.elements -= 1;
     }
 
-    /// Removes `slab_page` from the list.
-    pub(crate) fn pop<'b>(&'b mut self) -> Option<&'a mut T> {
+    /// Removes the MappedPages8k from the front of the list.
+    pub(crate) fn pop(&mut self) -> Option<MappedPages8k> {
         match self.head {
             None => None,
             Some(ref mut head) => {
-                let head_next = head.next();
-                let mut new_head = unsafe { head_next.resolve_mut() };
-                mem::swap(&mut self.head, &mut new_head);
-                let _ = self.head.as_mut().map(|n| {
-                    *n.prev() = Rawlink::none();
-                });
-
+                let head_next = head.next().take();
+                let old_head = self.head.take();
+                self.head = head_next; 
                 self.elements -= 1;
-                new_head.map(|node| {
-                    *node.prev() = Rawlink::none();
-                    *node.next() = Rawlink::none();
-                    node
-                })
+
+                old_head
             }
         }
     }
 
-    /// Does the list contain `s`?
-    pub(crate) fn contains(&mut self, s: *const T) -> bool {
+    /// Does the list contain a MappedPages8k starting with the address `addr`?
+    pub(crate) fn contains(&mut self, addr: VirtualAddress) -> bool {
         for slab_page in self.iter_mut() {
-            if slab_page as *const T == s as *const T {
+            if slab_page.start_address() == addr {
                 return true;
             }
         }
@@ -489,24 +467,65 @@ impl<'a, T: AllocablePage> PageList<'a, T> {
     pub(crate) fn is_empty(&self) -> bool {
         self.elements == 0
     }
+
+    /// Print the starting address of all the elements in the list
+    pub(crate) fn print(&mut self) {
+        trace!("list");
+        let page_iter = self.iter_mut();
+        for page in page_iter {
+            trace!("{:#X}", page.start_address())
+        }
+        trace!(" ");
+    }
+}
+
+/// Simple test to check the working of PageList.
+/// Remove alignment requirement from MappedPages8k before running
+pub fn test_page_list() -> Result<(), &'static str>{
+    let mut list = PageList::new();
+    let mut addr: [VirtualAddress; 10] = [VirtualAddress::new_canonical(0); 10];
+
+    for i in 0..10 {
+        let mut mp = create_mapping(8192, EntryFlags::WRITABLE)?;
+        let mut mp_8k = MappedPages8k::new(mp)?;
+        addr[i] = mp_8k.start_address();
+
+        list.insert_front(mp_8k);
+        list.print();
+    }
+
+    list.remove_from_list(addr[3]).ok_or("Couldn't find address in list")?;
+    list.print();
+
+    list.remove_from_list(addr[8]).ok_or("Couldn't find address in list")?;
+    list.print();
+
+    while !list.is_empty() {
+        list.pop();
+        list.print();
+    }
+
+    Ok(())
+
+
 }
 
 /// Iterate over all the pages inside a slab allocator
-pub(crate) struct ObjectPageIterMut<'a, P: AllocablePage> {
-    head: Rawlink<P>,
-    phantom: core::marker::PhantomData<&'a P>,
+pub(crate) struct MappedPages8kIterMut<'a> {
+    head: Rawlink<MappedPages8k>,
+    phantom: core::marker::PhantomData<&'a MappedPages8k>,
 }
 
-impl<'a, P: AllocablePage + 'a> Iterator for ObjectPageIterMut<'a, P> {
-    type Item = &'a mut P;
+impl<'a> Iterator for MappedPages8kIterMut<'a> {
+    type Item = &'a mut MappedPages8k;
 
     #[inline]
-    fn next(&mut self) -> Option<&'a mut P> {
+    fn next(&mut self) -> Option<&'a mut MappedPages8k> {
         unsafe {
             self.head.resolve_mut().map(|next| {
-                self.head = match next.next().resolve_mut() {
+                self.head = match next.next() {
                     None => Rawlink::none(),
-                    Some(ref mut sp) => Rawlink::some(*sp),
+                    Some(ref mut sp) => Rawlink::some(sp),
                 };
                 next
             })
@@ -568,126 +587,3 @@ impl<T> Rawlink<T> {
     }
 }
 
-
-
-// /// Holds allocated data within a 2 MiB page.
-// ///
-// /// Has a data-section where objects are allocated from
-// /// and a small amount of meta-data in form of a bitmap
-// /// to track allocations at the end of the page.
-// ///
-// /// # Notes
-// /// An object of this type will be exactly 2 MiB.
-// /// It is marked `repr(C)` because we rely on a well defined order of struct
-// /// members (e.g., dealloc does a cast to find the bitfield).
-// #[repr(C)]
-// pub struct LargeObjectPage<'a> {
-//     /// Holds memory objects.
-//     #[allow(dead_code)]
-//     data: [u8; (2 * 1024 * 1024) - 80],
-
-//     /// Next element in list (used by `PageList`).
-//     next: Rawlink<LargeObjectPage<'a>>,
-//     prev: Rawlink<LargeObjectPage<'a>>,
-
-//     /// A bit-field to track free/allocated memory within `data`.
-//     pub(crate) bitfield: [u64; 8],
-// }
-
-// // These needs some more work to be really safe...
-// unsafe impl<'a> Send for LargeObjectPage<'a> {}
-// unsafe impl<'a> Sync for LargeObjectPage<'a> {}
-
-// impl<'a> AllocablePage for LargeObjectPage<'a> {
-//     const SIZE: usize = LARGE_PAGE_SIZE;
-
-//     fn bitfield(&self) -> &[u64; 8] {
-//         &self.bitfield
-//     }
-
-//     fn bitfield_mut(&mut self) -> &mut [u64; 8] {
-//         &mut self.bitfield
-//     }
-
-//     fn prev(&mut self) -> &mut Rawlink<Self> {
-//         &mut self.prev
-//     }
-
-//     fn next(&mut self) -> &mut Rawlink<Self> {
-//         &mut self.next
-//     }
-// }
-
-// impl<'a> Default for LargeObjectPage<'a> {
-//     fn default() -> LargeObjectPage<'a> {
-//         unsafe { mem::MaybeUninit::zeroed().assume_init() }
-//     }
-// }
-
-// impl<'a> fmt::Debug for LargeObjectPage<'a> {
-//     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-//         write!(f, "LargeObjectPage")
-//     }
-// }
-
-// /// Holds allocated data within a 4 KiB page.
-// ///
-// /// Has a data-section where objects are allocated from
-// /// and a small amount of meta-data in form of a bitmap
-// /// to track allocations at the end of the page.
-// ///
-// /// # Notes
-// /// An object of this type will be exactly 4 KiB.
-// /// It is marked `repr(C)` because we rely on a well defined order of struct
-// /// members (e.g., dealloc does a cast to find the bitfield).
-// #[repr(C)]
-// pub struct ObjectPage<'a> {
-//     /// Holds memory objects.
-//     #[allow(dead_code)]
-//     data: [u8; 4096 - 88],
-
-//     pub heap_id: usize,
-
-//     /// Next element in list (used by `PageList`).
-//     next: Rawlink<ObjectPage<'a>>,
-//     /// Previous element in  list (used by `PageList`)
-//     prev: Rawlink<ObjectPage<'a>>,
-
-//     /// A bit-field to track free/allocated memory within `data`.
-//     pub(crate) bitfield: [u64; 8],
-// }
-
-// // These needs some more work to be really safe...
-// unsafe impl<'a> Send for ObjectPage<'a> {}
-// unsafe impl<'a> Sync for ObjectPage<'a> {}
-
-// impl<'a> AllocablePage for ObjectPage<'a> {
-//     const SIZE: usize = BASE_PAGE_SIZE;
-
-//     fn bitfield(&self) -> &[u64; 8] {
-//         &self.bitfield
-//     }
-//     fn bitfield_mut(&mut self) -> &mut [u64; 8] {
-//         &mut self.bitfield
-//     }
-
-//     fn prev(&mut self) -> &mut Rawlink<Self> {
-//         &mut self.prev
-//     }
-
-//     fn next(&mut self) -> &mut Rawlink<Self> {
-//         &mut self.next
-//     }
-// }
-
-// impl<'a> Default for ObjectPage<'a> {
-//     fn default() -> ObjectPage<'a> {
-//         unsafe { mem::MaybeUninit::zeroed().assume_init() }
-//     }
-// }
-
-// impl<'a> fmt::Debug for ObjectPage<'a> {
-//     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-//         write!(f, "ObjectPage")
-//     }
-// }

--- a/src/sc.rs
+++ b/src/sc.rs
@@ -44,7 +44,7 @@ fn cmin(a: usize, b: usize) -> usize {
 ///
 /// If an allocation returns `OutOfMemory` a client using SCAllocator can refill
 /// it using the `refill` function.
-pub struct SCAllocator<'a, P: AllocablePage> {
+pub struct SCAllocator {
     /// Maximum possible allocation size for this `SCAllocator`.
     pub(crate) size: usize,
     /// Keeps track of succeeded allocations.
@@ -52,11 +52,11 @@ pub struct SCAllocator<'a, P: AllocablePage> {
     /// max objects per page
     pub(crate) obj_per_page: usize,
     /// List of empty ObjectPages (nothing allocated in these).
-    pub(crate) empty_slabs: PageList<'a, P>,
+    pub(crate) empty_slabs: PageList,
     /// List of partially used ObjectPage (some objects allocated but pages are not full).
-    pub(crate) slabs: PageList<'a, P>,
+    pub(crate) slabs: PageList,
     /// List of full ObjectPages (everything allocated in these don't need to search them).
-    pub(crate) full_slabs: PageList<'a, P>,
+    pub(crate) full_slabs: PageList,
 }
 
 /// Creates an instance of a scallocator, we do this in a macro because we
@@ -66,7 +66,7 @@ macro_rules! new_sc_allocator {
         SCAllocator {
             size: $size,
             allocation_count: 0,
-            obj_per_page: cmin((P::SIZE - P::METADATA_SIZE) / $size, 8 * 64),
+            obj_per_page: cmin((MappedPages8k::SIZE - MappedPages8k::METADATA_SIZE) / $size, 8 * 64),
             empty_slabs: PageList::new(),
             slabs: PageList::new(),
             full_slabs: PageList::new(),
@@ -74,17 +74,17 @@ macro_rules! new_sc_allocator {
     };
 }
 
-impl<'a, P: AllocablePage> SCAllocator<'a, P> {
+impl SCAllocator {
     const _REBALANCE_COUNT: usize = 10_000;
 
     /// Create a new SCAllocator.
     #[cfg(feature = "unstable")]
-    pub const fn new(size: usize) -> SCAllocator<'a, P> {
+    pub const fn new(size: usize) -> SCAllocator {
         new_sc_allocator!(size)
     }
 
     #[cfg(not(feature = "unstable"))]
-    pub fn new(size: usize) -> SCAllocator<'a, P> {
+    pub fn new(size: usize) -> SCAllocator {
         new_sc_allocator!(size)
     }
 
@@ -94,29 +94,29 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
     }
 
     /// Add a new ObjectPage.
-    fn insert_partial_slab(&mut self, new_head: &'a mut P) {
+    fn insert_partial_slab(&mut self, new_head: MappedPages8k) {
         self.slabs.insert_front(new_head);
     }
 
     /// Add page to empty list.
-    fn insert_empty(&mut self, new_head: &'a mut P) {
-        assert_eq!(
-            new_head as *const P as usize % P::SIZE,
-            0,
-            "Inserted page is not aligned to page-size."
-        );
+    fn insert_empty(&mut self, new_head: MappedPages8k) {
+        // assert_eq!(
+        //     new_head as *const MappedPages8k as usize % MappedPages8k::SIZE,
+        //     0,
+        //     "Inserted page is not aligned to page-size."
+        // );
         self.empty_slabs.insert_front(new_head);
     }
 
-    fn remove_empty(&mut self) -> Option<&'a mut P> {
+    fn remove_empty(&mut self) -> Option<MappedPages8k> {
         self.empty_slabs.pop()
     }
 
-    fn remove_partial(&mut self) -> Option<&'a mut P> {
+    fn remove_partial(&mut self) -> Option<MappedPages8k> {
         self.slabs.pop()
     }
 
-    fn remove_full(&mut self) -> Option<&'a mut P> {
+    fn remove_full(&mut self) -> Option<MappedPages8k> {
         self.full_slabs.pop()
     }
     
@@ -141,50 +141,43 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
     //     }
     // }
 
-    /// Move a page from `slabs` to `empty_slabs`.
-    fn move_to_empty(&mut self, page: &'a mut P) {
-        let page_ptr = page as *const P;
-
-        debug_assert!(self.slabs.contains(page_ptr));
+    /// Move a page with the starting address `page_addr` from `slabs` to `empty_slabs`.
+    fn move_to_empty(&mut self, page_addr: VirtualAddress) {
+        debug_assert!(self.slabs.contains(page_addr));
         debug_assert!(
-            !self.empty_slabs.contains(page_ptr),
-            "Page {:p} already in emtpy_slabs",
-            page_ptr
+            !self.empty_slabs.contains(page_addr),
+            "Page {:p} already in empty_slabs",
+            page_addr
         );
+        let page_to_move = self.slabs.remove_from_list(page_addr).unwrap();
+        self.empty_slabs.insert_front(page_to_move);
 
-        self.slabs.remove_from_list(page);
-        self.empty_slabs.insert_front(page);
-
-        debug_assert!(!self.slabs.contains(page_ptr));
-        debug_assert!(self.empty_slabs.contains(page_ptr));
+        debug_assert!(!self.slabs.contains(page_addr));
+        debug_assert!(self.empty_slabs.contains(page_addr));
     }
 
-    /// Move a page from `full_slabs` to `slab`.
-    fn move_partial_to_full(&mut self, page: &'a mut P) {
-        let page_ptr = page as *const P;
+    /// Move a page with the starting address `page_addr` from `slab` to `full_slabs`.
+    fn move_partial_to_full(&mut self, page_addr: VirtualAddress) { 
+        debug_assert!(self.slabs.contains(page_addr));
+        debug_assert!(!self.full_slabs.contains(page_addr));
 
-        debug_assert!(self.slabs.contains(page_ptr));
-        debug_assert!(!self.full_slabs.contains(page_ptr));
+        let page_to_move = self.slabs.remove_from_list(page_addr).unwrap();
+        self.full_slabs.insert_front(page_to_move);
 
-        self.slabs.remove_from_list(page);
-        self.full_slabs.insert_front(page);
-
-        debug_assert!(!self.slabs.contains(page_ptr));
-        debug_assert!(self.full_slabs.contains(page_ptr));
+        debug_assert!(!self.slabs.contains(page_addr));
+        debug_assert!(self.full_slabs.contains(page_addr));
     }
 
-    /// Move a page from `full_slabs` to `slab`.
-    fn move_full_to_partial(&mut self, page: &'a mut P) {
-        let page_ptr = page as *const P;
+    /// Move a page with the starting address `page_addr` from `full_slabs` to `slab`.
+    fn move_full_to_partial(&mut self, page_addr: VirtualAddress) {
+        debug_assert!(!self.slabs.contains(page_addr));
+        debug_assert!(self.full_slabs.contains(page_addr));
 
-        debug_assert!(!self.slabs.contains(page_ptr));
-        debug_assert!(self.full_slabs.contains(page_ptr));
+        let page_to_move = self.full_slabs.remove_from_list(page_addr).unwrap();
+        self.slabs.insert_front(page_to_move);
 
-        self.full_slabs.remove_from_list(page);
-        self.slabs.insert_front(page);
-
-        debug_assert!(self.slabs.contains(page_ptr));
-        debug_assert!(!self.full_slabs.contains(page_ptr));
+        debug_assert!(self.slabs.contains(page_addr));
+        debug_assert!(!self.full_slabs.contains(page_addr));
     }
 
     /// Tries to allocate a block of memory with respect to the `layout`.
@@ -204,7 +197,7 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
             if !ptr.is_null() {
                 if slab_page.is_full() {
                     // trace!("move {:p} partial -> full", slab_page);
-                    self.move_partial_to_full(slab_page);
+                    self.move_partial_to_full(slab_page.start_address());
                 }
                 self.allocation_count += 1;
                 return ptr;
@@ -221,25 +214,12 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
         ptr::null_mut()
     }
 
-    pub fn heap_id(&self) -> Option<usize> {
-        if let Some(head) = &self.empty_slabs.head {
-            return Some(head.heap_id())
-        }
-        if let Some(head) = &self.slabs.head {
-            return Some(head.heap_id())
-        }
-        if let Some(head) = &self.full_slabs.head {
-            return Some(head.heap_id())
-        }
-
-        None
-    }
 
     /// removes all of the pages from the lists of `allocator` and adds them to this allocator.
-    pub fn merge(&mut self, allocator: &mut SCAllocator<'a, P>, heap_id: usize) -> Result<(), &'static str> {
+    pub fn merge(&mut self, allocator: &mut SCAllocator, heap_id: usize) -> Result<(), &'static str> {
         while !allocator.empty_slabs.is_empty() {
             match allocator.remove_empty() {
-                Some(new_head) =>{
+                Some(mut new_head) =>{
                     new_head.set_heap_id(heap_id);
                     self.empty_slabs.insert_front(new_head)
                 }
@@ -251,7 +231,7 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
 
         while !allocator.slabs.is_empty() {
             match allocator.remove_partial() {
-                Some(new_head) =>{
+                Some(mut new_head) =>{
                     new_head.set_heap_id(heap_id);
                     self.slabs.insert_front(new_head)
                 }
@@ -263,7 +243,7 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
 
         while !allocator.full_slabs.is_empty() {
             match allocator.remove_full() {
-                Some(new_head) =>{
+                Some(mut new_head) =>{
                     new_head.set_heap_id(heap_id);
                     self.full_slabs.insert_front(new_head)
                 }
@@ -277,42 +257,39 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
 
     }
 
-    /// Creates an allocable page given a MappedPages object and returns a reference to the allocable page.
-    /// The MappedPages object is stored within the metadata of the allocable page.
-    fn create_allocable_page(mp: MappedPages, heap_id: usize) -> Result<&'a mut P, &'static str> {
-        let vaddr = mp.start_address().value();
+    // /// Creates an allocable page given a MappedPages object and returns a reference to the allocable page.
+    // /// The MappedPages object is stored within the metadata of the allocable page.
+    // fn create_allocable_page(mp: MappedPages8k, heap_id: usize) -> Result<&'a mut MappedPages8k, &'static str> {
+    //     // let vaddr = mp.start_address().value();
 
-        // create page and store the MappedPages object
-        let page = P::new(mp, heap_id)?;
-        let page_ref: &'a mut P = unsafe { core::mem::transmute(vaddr) } ; // not unsafe because the allocable page was only create by a mapped page that fit the criteria
-        unsafe { (page_ref as *mut P).write(page); }
+    //     // let mut mp_8k = MappedPages8k::new(mp, heap_id)?;
+    //     let obj_page = mp.as_ObjectPage8k_mut();
+    //     obj_page.clear_metadata();
 
-        Ok(page_ref) 
-    }
+    //     // // create page and store the MappedPages object
+    //     // let page = MappedPages8k::new(mp, heap_id)?;
+    //     // let page_ref: &'a mut P = unsafe { core::mem::transmute(vaddr) } ; // not unsafe because the allocable page was only create by a mapped page that fit the criteria
+    //     // unsafe { (page_ref as *mut P).write(page); }
+
+    //     // Ok(page_ref) 
+    // }
 
     /// Refill the SCAllocator
-    pub fn refill(&mut self, mp: MappedPages, heap_id: usize) -> Result<(), &'static str> {
-        let page = Self::create_allocable_page(mp, heap_id)?;
-        page.bitfield_mut().initialize(self.size, P::SIZE - P::METADATA_SIZE);
-        *page.prev() = Rawlink::none();
-        *page.next() = Rawlink::none();
+    pub fn refill(&mut self,mut mp: MappedPages8k, heap_id: usize) -> Result<(), &'static str> {
+        // let page = Self::create_allocable_page(mp, heap_id)?;
+        mp.clear_metadata();
+        mp.bitfield_mut().initialize(self.size, MappedPages8k::SIZE - MappedPages8k::METADATA_SIZE);
+        mp.set_heap_id(heap_id);
         // trace!("adding page to SCAllocator {:p}", page);
-        self.insert_empty(page);
+        self.insert_empty(mp);
 
         Ok(())
     }
 
     /// Returns an empty page from the allocator if available.
     /// It removes the MappedPages object from the heap pages where it is stored.
-    pub fn retrieve_empty_page(&mut self) -> Option<MappedPages> {
-        match self.remove_empty(){
-            Some(page) => {
-                Some(page.retrieve_mapped_pages()) //safe because the page has been removed from the heap's linked lists
-            }
-            None => {
-                None
-            }
-        }
+    pub fn retrieve_empty_page(&mut self) -> Option<MappedPages8k> {
+        self.remove_empty()
     }
 
     /// Allocates a block of memory descriped by `layout`.
@@ -327,10 +304,11 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
         //     "SCAllocator({}) is trying to allocate {:?}, {}",
         //     self.size,
         //     layout, 
-        //     P::SIZE - CACHE_LINE_SIZE
+        //     MappedPages8k::SIZE - CACHE_LINE_SIZE
         // );
+
         assert!(layout.size() <= self.size);
-        assert!(self.size <= (P::SIZE - CACHE_LINE_SIZE));
+        assert!(self.size <= (MappedPages8k::SIZE - CACHE_LINE_SIZE));
         let new_layout = unsafe { Layout::from_size_align_unchecked(self.size, layout.align()) };
         assert!(new_layout.size() >= layout.size());
 
@@ -340,15 +318,15 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
             let ptr = self.try_allocate_from_pagelist(new_layout);
             if ptr.is_null() && self.empty_slabs.head.is_some() {
                 // Re-try allocation in empty page
-                let empty_page = self.empty_slabs.pop().expect("We checked head.is_some()");
-                debug_assert!(!self.empty_slabs.contains(empty_page));
+                let mut empty_page = self.empty_slabs.pop().expect("We checked head.is_some()");
+                debug_assert!(!self.empty_slabs.contains(empty_page.start_address()));
 
                 let ptr = empty_page.allocate(layout);
                 debug_assert!(!ptr.is_null(), "Allocation must have succeeded here.");
 
                 // trace!(
-                //     "move {:p} empty -> partial empty count {}",
-                //     empty_page,
+                //     "move {:#X} empty -> partial empty count {}",
+                //     empty_page.start_address(),
                 //     self.empty_slabs.elements
                 // );
                 // Move empty page to partial pages
@@ -379,20 +357,30 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
     /// or full -> partial lists.
     pub fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
         assert!(layout.size() <= self.size);
-        assert!(self.size <= (P::SIZE - CACHE_LINE_SIZE));
+        assert!(self.size <= (MappedPages8k::SIZE - CACHE_LINE_SIZE));
         // trace!(
         //     "SCAllocator({}) is trying to deallocate ptr = {:p} layout={:?} P.size= {}",
         //     self.size,
         //     ptr,
         //     layout,
-        //     P::SIZE
+        //     MappedPages8k::SIZE
         // );
 
-        let page = (ptr.as_ptr() as usize) & !(P::SIZE - 1) as usize;
+        let page = (ptr.as_ptr() as usize) & !(MappedPages8k::SIZE - 1) as usize;
+        let page_addr = VirtualAddress::new(page)?;
 
         // Figure out which page we are on and construct a reference to it
         // TODO: The linked list will have another &mut reference
-        let slab_page = unsafe { mem::transmute::<VAddr, &'a mut P>(page) };
+        let slab_page = self.slabs.iter_mut().find(|mp| mp.start_address() == page_addr).or_else(|| self.full_slabs.iter_mut().find(|mp| mp.start_address() == page_addr));//.expect("The page is not in the full or partial slabs!");
+        
+        // self.slabs.print();
+        // self.empty_slabs.print();
+        // self.full_slabs.print();
+        // loop{}
+        let new_layout = unsafe { Layout::from_size_align_unchecked(self.size, layout.align()) };
+
+
+        let slab_page = unsafe { mem::transmute::<VAddr, &mut ObjectPage8k>(page) };
         let new_layout = unsafe { Layout::from_size_align_unchecked(self.size, layout.align()) };
 
         let slab_page_was_full = slab_page.is_full();
@@ -401,14 +389,16 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
 
         if slab_page.is_empty(self.obj_per_page) {
             // We need to move it from self.slabs -> self.empty_slabs
-            // trace!("move {:p} partial -> empty", slab_page);
-            self.move_to_empty(slab_page);
+            // trace!("move {:p} {:#X} partial -> empty", slab_page, VirtualAddress::new(page)?);
+            self.move_to_empty(VirtualAddress::new(page)?);
         } else if slab_page_was_full {
             // We need to move it from self.full_slabs -> self.slabs
             // trace!("move {:p} full -> partial", slab_page);
-            self.move_full_to_partial(slab_page);
+            self.move_full_to_partial(VirtualAddress::new(page)?);
         }
 
         ret
+
+        // Ok(())
     }
 }

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -12,6 +12,8 @@ macro_rules! new_zone {
     ($x:expr) => {
         ZoneAllocator {
             heap_id: $x,
+            allocated: 0,
+            used: 0,
             // TODO(perf): We should probably pick better classes
             // rather than powers-of-two (see SuperMalloc etc.)
             small_slabs: [
@@ -25,7 +27,7 @@ macro_rules! new_zone {
                 SCAllocator::new(1 << 10), // 1024 (TODO: maybe get rid of this class?)
                 SCAllocator::new(1 << 11), // 2048 (TODO: maybe get rid of this class?)
                 SCAllocator::new(1 << 12), // 4096 
-                SCAllocator::new(ZoneAllocator::MAX_ALLOC_SIZE),    // 8104 (can't do 8192 because of metadata in ObjectPage)
+                SCAllocator::new(ZoneAllocator::MAX_ALLOC_SIZE),    // (can't do 8192 because of metadata in ObjectPage)
             ]
         }
     };
@@ -37,12 +39,15 @@ macro_rules! new_zone {
 /// requests for many different object sizes up to (MAX_SIZE_CLASSES) by selecting
 /// the right `SCAllocator` for allocation and deallocation.
 ///
-/// The allocator provides to refill functions `refill` and `refill_large`
+/// The allocator provides the refill function `refill`
 /// to provide the underlying `SCAllocator` with more memory in case it runs out.
 pub struct ZoneAllocator {
     pub heap_id: usize,
+    /// The total number of bytes given to this allocator from the system.
+    allocated: usize,
+    /// The total number of bytes actually allocated (in use).
+    used: usize,
     small_slabs: [SCAllocator; ZoneAllocator::MAX_BASE_SIZE_CLASSES],
-    // big_slabs: [SCAllocator<'a, LargeObjectPage<'a>>; ZoneAllocator::MAX_LARGE_SIZE_CLASSES],
 }
 
 impl<'a> Default for ZoneAllocator {
@@ -60,16 +65,16 @@ enum Slab {
 
 
 impl ZoneAllocator {
-    /// Maximum size that allocated within 2 pages. (8 KiB - 88 bytes)
+    /// Maximum size that's allocated within 2 pages as given by MappedPages8k.
     /// This is also the maximum object size that this allocator can handle.
     pub const MAX_ALLOC_SIZE: usize = MappedPages8k::SIZE - MappedPages8k::METADATA_SIZE;
 
-    /// Maximum size which is allocated with ObjectPages8k (4 KiB pages).
+    /// Maximum size which is allocated with MappedPages8k.
     ///
-    /// e.g. this is 8 KiB - 88 bytes of meta-data.
+    /// e.g. this is 8 KiB - x bytes of meta-data.
     pub const MAX_BASE_ALLOC_SIZE: usize = ZoneAllocator::MAX_ALLOC_SIZE;
 
-    /// How many allocators of type SCAllocator<ObjectPage8k> we have.
+    /// How many allocators of type SCAllocator<MappedPages8k> we have.
     pub const MAX_BASE_SIZE_CLASSES: usize = 11;
 
     /// The set of sizes the allocator has lists for.
@@ -130,22 +135,8 @@ impl ZoneAllocator {
 
 impl<'a> ZoneAllocator {
 
-    /// Removes all the pages of `allocator` and adds them to the appropriate lists in this allocator.
-    pub fn merge(&mut self, allocator: &mut ZoneAllocator) -> Result<(), &'static str> {
-        for size in &ZoneAllocator::BASE_ALLOC_SIZES {
-            match ZoneAllocator::get_slab(*size) {
-                Slab::Base(idx) => {
-                    self.small_slabs[idx].merge(&mut allocator.small_slabs[idx], self.heap_id)?;
-                }
-                Slab::Large(_idx) => return Err("AllocationError::InvalidLayout"),
-                Slab::Unsupported => return Err("AllocationError::InvalidLayout"),
-            }
-        }
-        Ok(())
-    }
-
-    /// Returns an ObjectPage from the SCAllocator with the maximum number of empty pages,
-    /// if there are more empty pages than the threshold.
+    /// Returns a MappedPages8k from the SCAllocator with the maximum number of empty pages,
+    /// if there are more empty pages than the threshold, and updates the heap statistics.
     pub fn retrieve_empty_page(
         &mut self,
         heap_empty_page_threshold: usize
@@ -157,6 +148,7 @@ impl<'a> ZoneAllocator {
             for slab in self.small_slabs.iter_mut() {
                 let empty_pages = slab.empty_slabs.elements;
                 if empty_pages > ZoneAllocator::SLAB_EMPTY_PAGES_THRESHOLD {
+                    self.allocated -= MappedPages8k::BUFFER_SIZE;
                     return slab.retrieve_empty_page()
                 }
             }
@@ -164,6 +156,7 @@ impl<'a> ZoneAllocator {
         None
     }
 
+    /// Moves empty pages between the SCAllocators
     pub fn exchange_pages_within_heap(&mut self, layout: Layout) -> Result<(), &'static str> {
         let mp = self.retrieve_empty_page(0).ok_or("Couldn't find an empty page to exchange within the heap")?;
         self.refill(layout, mp)
@@ -180,15 +173,19 @@ impl<'a> ZoneAllocator {
 }
 
 unsafe impl<'a> crate::Allocator<'a> for ZoneAllocator {
-    /// Allocate a pointer to a block of memory described by `layout`.
+    /// Allocate a pointer to a block of memory described by `layout`
+    /// and update heap statistics.
     fn allocate(&mut self, layout: Layout) -> Result<NonNull<u8>, &'static str> {
         match ZoneAllocator::get_slab(layout.size()) {
             Slab::Base(idx) => {
                 match self.small_slabs[idx].allocate(layout) {
-                    Ok(ptr) => Ok(ptr),
+                    Ok(ptr) => {
+                        self.used += layout.size();
+                        Ok(ptr)
+                    },
                     Err(_e) => {
                         self.exchange_pages_within_heap(layout)?;
-                        self.small_slabs[idx].allocate(layout)
+                        self.small_slabs[idx].allocate(layout).and_then(|ptr| {self.used += layout.size(); Ok(ptr)} )
                     }
                 }
             }
@@ -198,7 +195,7 @@ unsafe impl<'a> crate::Allocator<'a> for ZoneAllocator {
     }
 
     /// Deallocates a pointer to a block of memory, which was
-    /// previously allocated by `allocate`.
+    /// previously allocated by `allocate`, and updates heap statistics.
     ///
     /// # Arguments
     ///  * `ptr` - Address of the memory location to free.
@@ -206,16 +203,14 @@ unsafe impl<'a> crate::Allocator<'a> for ZoneAllocator {
     fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
         match ZoneAllocator::get_slab(layout.size()) {
             Slab::Base(idx) => {
-                self.small_slabs[idx].deallocate(ptr, layout)},
+                self.small_slabs[idx].deallocate(ptr, layout).and_then(|()| {self.used -= layout.size(); Ok(())})},
             Slab::Large(_idx) => Err("AllocationError::InvalidLayout"),
             Slab::Unsupported => Err("AllocationError::InvalidLayout"),
         }
     }
 
-    /// Refills the SCAllocator for a given Layout with an ObjectPage.
-    ///
-    /// # Safety
-    /// ObjectPage needs to be empty etc.
+    /// Refills the SCAllocator for a given Layout with a MappedPages8k object
+    /// and updates heap statistics.
     fn refill(
         &mut self,
         layout: Layout,
@@ -223,7 +218,7 @@ unsafe impl<'a> crate::Allocator<'a> for ZoneAllocator {
     ) -> Result<(), &'static str> {
         match ZoneAllocator::get_slab(layout.size()) {
             Slab::Base(idx) => {
-                self.small_slabs[idx].refill(mp, self.heap_id)
+                self.small_slabs[idx].refill(mp, self.heap_id).and_then(|()| {self.allocated += MappedPages8k::BUFFER_SIZE; Ok(())})
             }
             Slab::Large(_idx) => Err("AllocationError::InvalidLayout"),
             Slab::Unsupported => Err("AllocationError::InvalidLayout"),


### PR DESCRIPTION
- Created a MappedPages8k type which ensures that heap pages meet size and alignment requirements

-     Store the pages given to the allocator as a recursive list of MappedPages8k

-     Remove all transmute functions except when converting from MappedPages8k to ObjectPage8k
